### PR TITLE
DelegatingMarker.remove should call map.onRemove *before* real.remove

### DIFF
--- a/android-maps-extensions/src/pl/mg6/android/maps/extensions/impl/DelegatingMarker.java
+++ b/android-maps-extensions/src/pl/mg6/android/maps/extensions/impl/DelegatingMarker.java
@@ -97,8 +97,8 @@ class DelegatingMarker implements Marker {
 
 	@Override
 	public void remove() {
-		real.remove();
 		map.onRemove(this);
+		real.remove();
 	}
 
 	@Override


### PR DESCRIPTION
=> DelegatingGoogleMap.onRemove(DelegatingMarker marker) calls
createdMarkers.remove(marker.getReal().getMarker()), but getMarker()
always returns null at this point if the marker is removed before
calling onRemove, since LazyMarker#remove nulls it.
