### PR TITLE
Avoid NullPointerException

### DIFF
--- a/android-maps-extensions/src/pl/mg6/android/maps/extensions/lazy/LazyMarker.java
+++ b/android-maps-extensions/src/pl/mg6/android/maps/extensions/lazy/LazyMarker.java
@@ -171,13 +171,15 @@ public class LazyMarker {
 	}
 
 	public void setVisible(boolean visible) {
-		if (marker != null) {
-			marker.setVisible(visible);
-		} else if (visible) {
-			markerOptions.visible(true);
-			createMarker();
-		}
-	}
+        if (marker != null) {
+            marker.setVisible(visible);
+        } else if (visible) {
+            if (markerOptions != null)
+                markerOptions.visible(true);
+
+            createMarker();
+        }
+    }
 
 	public void showInfoWindow() {
 		if (marker != null) {


### PR DESCRIPTION
Try/catch is needed in createMarker(GoogleMap map, MarkerOptions options, OnMarkerCreateListener listener).  Otherwise, you may get a NullPointerException and your app will crash!
