### PR TITLE
added default gradle.properties containing empty sonatypeUserName and sonatypePassword

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+sonatypeUserName=
+sonatypePassword=


### PR DESCRIPTION
Using this library via gradle, I had the following error when trying to build:

```
no such property: sonatypeUserName
```

With this gradle.properties file, sonatypeUserName and sonatypePassword are set with empty values, avoiding the previous error.

If the user already has a sonatypeUserName set to deploy on maven in his **${GRADLE_HOME}/gradle.properties**, it already overrides the present file, so no changes are requested!
