### PR TITLE
Added support for Marker zIndex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 android:
   components:
-    - build-tools-23.0.1
+    - build-tools-23.0.3
     - android-23
     - extra-android-m2repository
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 android:
   components:
-	- platform-tools
+    - platform-tools
     - tools  
     - build-tools-23.0.3
     - android-23

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: android
 android:
   components:
+	- platform-tools
+    - tools  
     - build-tools-23.0.3
     - android-23
     - extra-android-m2repository

--- a/android-maps-extensions-demo/build.gradle
+++ b/android-maps-extensions-demo/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion '23.0.1'
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 23
     }
     dexOptions {
@@ -26,6 +26,6 @@ dependencies {
     compile (project (':android-maps-extensions')) {
         exclude module: 'play-services-maps'
     }
-    compile 'com.google.android.gms:play-services:3.2.65'
+    compile 'com.google.android.gms:play-services:9.2.0'
     compile 'com.android.support:appcompat-v7:23.0.1'
 }

--- a/android-maps-extensions-demo/build.gradle
+++ b/android-maps-extensions-demo/build.gradle
@@ -8,7 +8,7 @@ def isTravis = "true".equals(System.getenv("TRAVIS"))
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 9
@@ -26,6 +26,8 @@ dependencies {
     compile (project (':android-maps-extensions')) {
         exclude module: 'play-services-maps'
     }
-    compile 'com.google.android.gms:play-services:9.2.0'
+    compile 'com.google.android.gms:play-services-base:9.2.0'
+    compile 'com.google.android.gms:play-services-location:9.2.0'
+    compile 'com.google.android.gms:play-services-maps:9.2.0'
     compile 'com.android.support:appcompat-v7:23.0.1'
 }

--- a/android-maps-extensions-demo/src/main/java/pl/mg6/android/maps/extensions/demo/BaseFragment.java
+++ b/android-maps-extensions-demo/src/main/java/pl/mg6/android/maps/extensions/demo/BaseFragment.java
@@ -22,6 +22,7 @@ import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 
 import com.androidmapsextensions.GoogleMap;
+import com.androidmapsextensions.OnMapReadyCallback;
 import com.androidmapsextensions.SupportMapFragment;
 
 public abstract class BaseFragment extends Fragment {
@@ -57,12 +58,14 @@ public abstract class BaseFragment extends Fragment {
     }
 
     private void setUpMapIfNeeded() {
-        if (map == null) {
-            map = mapFragment.getExtendedMap();
-            if (map != null) {
+
+        mapFragment.getExtendedMapAsync(new OnMapReadyCallback() {
+            @Override
+            public void onMapReady(GoogleMap googleMap) {
+                map = googleMap;
                 setUpMap();
             }
-        }
+        });
     }
 
     protected abstract void setUpMap();

--- a/android-maps-extensions/build.gradle
+++ b/android-maps-extensions/build.gradle
@@ -10,7 +10,7 @@ def isTravis = "true".equals(System.getenv("TRAVIS"))
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 9

--- a/android-maps-extensions/build.gradle
+++ b/android-maps-extensions/build.gradle
@@ -13,7 +13,7 @@ android {
     buildToolsVersion '23.0.1'
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
     }
     dexOptions {
         preDexLibraries = !isTravis
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-maps:8.1.0'
+    compile 'com.google.android.gms:play-services-maps:9.2.0'
 }
 
 group = 'com.androidmapsextensions'

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/MapFragment.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/MapFragment.java
@@ -40,10 +40,6 @@ public class MapFragment extends com.google.android.gms.maps.MapFragment impleme
 
     private final MapHolder mapHolder = new MapHolder(this);
 
-    public GoogleMap getExtendedMap() {
-        return mapHolder.getExtendedMap();
-    }
-
     public void getExtendedMapAsync(OnMapReadyCallback callback) {
         mapHolder.getExtendedMapAsync(callback);
     }

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/MapHolder.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/MapHolder.java
@@ -8,8 +8,6 @@ final class MapHolder {
 
     public interface Delegate {
 
-        com.google.android.gms.maps.GoogleMap getMap();
-
         void getMapAsync(com.google.android.gms.maps.OnMapReadyCallback callback);
 
         Context getContext();
@@ -20,16 +18,6 @@ final class MapHolder {
 
     public MapHolder(Delegate delegate) {
         this.delegate = delegate;
-    }
-
-    public GoogleMap getExtendedMap() {
-        if (map == null) {
-            com.google.android.gms.maps.GoogleMap realMap = delegate.getMap();
-            if (realMap != null) {
-                map = ExtendedMapFactory.create(realMap, delegate.getContext());
-            }
-        }
-        return map;
     }
 
     public void getExtendedMapAsync(final OnMapReadyCallback callback) {

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/MapView.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/MapView.java
@@ -40,10 +40,6 @@ public class MapView extends com.google.android.gms.maps.MapView implements MapH
         super(context, options);
     }
 
-    public GoogleMap getExtendedMap() {
-        return mapHolder.getExtendedMap();
-    }
-
     public void getExtendedMapAsync(OnMapReadyCallback callback) {
         mapHolder.getExtendedMapAsync(callback);
     }

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/Marker.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/Marker.java
@@ -72,6 +72,8 @@ public interface Marker {
 
     String getTitle();
 
+    float getZIndex();
+
     void hideInfoWindow();
 
     /**
@@ -117,6 +119,8 @@ public interface Marker {
     void setTitle(String title);
 
     void setVisible(boolean visible);
+
+    void setZIndex(float zIndex);
 
     void showInfoWindow();
 }

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/MarkerOptions.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/MarkerOptions.java
@@ -102,6 +102,10 @@ public class MarkerOptions {
         return real.getTitle();
     }
 
+    public float getZIndex() {
+        return real.getZIndex();
+    }
+
     public MarkerOptions icon(BitmapDescriptor icon) {
         real.icon(icon);
         return this;
@@ -146,6 +150,11 @@ public class MarkerOptions {
 
     public MarkerOptions visible(boolean visible) {
         real.visible(visible);
+        return this;
+    }
+
+    public MarkerOptions zIndex(float zIndex) {
+        real.zIndex(zIndex);
         return this;
     }
 }

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/SupportMapFragment.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/SupportMapFragment.java
@@ -40,10 +40,6 @@ public class SupportMapFragment extends com.google.android.gms.maps.SupportMapFr
 
     private final MapHolder mapHolder = new MapHolder(this);
 
-    public GoogleMap getExtendedMap() {
-        return mapHolder.getExtendedMap();
-    }
-
     public void getExtendedMapAsync(OnMapReadyCallback callback) {
         mapHolder.getExtendedMapAsync(callback);
     }

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/ClusterMarker.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/ClusterMarker.java
@@ -191,6 +191,11 @@ class ClusterMarker implements Marker {
     }
 
     @Override
+    public float getZIndex() {
+        return 0;
+    }
+
+    @Override
     public void hideInfoWindow() {
         if (virtual != null) {
             virtual.hideInfoWindow();
@@ -300,6 +305,11 @@ class ClusterMarker implements Marker {
 
     @Override
     public void setVisible(boolean visible) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setZIndex(float zIndex) {
         throw new UnsupportedOperationException();
     }
 

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/DelegatingMarker.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/DelegatingMarker.java
@@ -115,6 +115,11 @@ class DelegatingMarker implements Marker {
     }
 
     @Override
+    public float getZIndex() {
+        return real.getZIndex();
+    }
+
+    @Override
     public void hideInfoWindow() {
         real.hideInfoWindow();
     }
@@ -227,6 +232,11 @@ class DelegatingMarker implements Marker {
             this.visible = visible;
             manager.onVisibilityChangeRequest(this, visible);
         }
+    }
+
+    @Override
+    public void setZIndex(float zIndex) {
+        real.zIndex(zIndex);
     }
 
     @Override

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/lazy/LazyMarker.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/lazy/LazyMarker.java
@@ -99,6 +99,14 @@ public class LazyMarker {
         }
     }
 
+    public float getZIndex() {
+        if (marker != null) {
+            return marker.getZIndex();
+        } else {
+            return markerOptions.getZIndex();
+        }
+    }
+
     public void hideInfoWindow() {
         if (marker != null) {
             marker.hideInfoWindow();
@@ -237,6 +245,14 @@ public class LazyMarker {
         }
     }
 
+    public void zIndex(float zIndex) {
+        if (marker != null) {
+            marker.setZIndex(zIndex);
+        } else {
+            markerOptions.zIndex(zIndex);
+        }
+    }
+
     public void showInfoWindow() {
         if (marker != null) {
             marker.showInfoWindow();
@@ -279,6 +295,7 @@ public class LazyMarker {
         copy.snippet(options.getSnippet());
         copy.title(options.getTitle());
         copy.visible(options.isVisible());
+        copy.zIndex(options.getZIndex());
         return copy;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.11.3'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 20 11:35:33 CET 2014
+#Sun Jul 03 17:48:51 EEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Added support for Marker zIndex, introduced in Google play services maps 9.2.0.

**Breaking changes**
- Removed getExtendedMap() as getMap() is not any more available in Google play services sdk
- minSdkVersion is now 9